### PR TITLE
add 5.18.2 to module search path for compatibility with current rosa version

### DIFF
--- a/perl.spec
+++ b/perl.spec
@@ -16,7 +16,7 @@ Summary:	The Perl programming language
 Name:		perl
 Epoch:		2
 Version:	%{major}.3
-Release:	2
+Release:	3
 License:	GPL+ or Artistic
 Group:		Development/Perl
 Url:		http://www.perl.org/
@@ -209,7 +209,7 @@ sed -i '/\(bzip2\|zlib\)-src/d' MANIFEST
 export AFLAGS="-Wl,--hash-style=both"
 %endif
 sh Configure -des \
-  -Dinc_version_list="5.20.2 5.20.2/%{full_arch} 5.20.1 5.20.1/%{full_arch} 5.20.0 5.20.0/%{full_arch} 5.16.3 5.16.3/%{full_arch} 5.16.2 5.16.2/%{full_arch} 5.16.1 5.16.1/%{full_arch} 5.16.0 5.16.0/%{full_arch} 5.14.2 5.14.1 5.14.0 5.12.3 5.12.2 5.12.1 5.12.0" \
+  -Dinc_version_list="5.20.2 5.20.2/%{full_arch} 5.20.1 5.20.1/%{full_arch} 5.20.0 5.20.0/%{full_arch} 5.18.2 5.18.2/%{full_arch} 5.16.3 5.16.3/%{full_arch} 5.16.2 5.16.2/%{full_arch} 5.16.1 5.16.1/%{full_arch} 5.16.0 5.16.0/%{full_arch} 5.14.2 5.14.1 5.14.0 5.12.3 5.12.2 5.12.1 5.12.0" \
   -Darchname=%{_arch}-%{_os} \
   -Dcc='%{__cc}' \
 %if %debugging


### PR DESCRIPTION
As rosa is currently  using perl 5.18.2, for which cooker skipped right ahead, from 5.16.3 to 5.20.0, modules built for this version isn't in search path.

Being on a hybrid rosa cooker version, this caused me some grief when some package that I installed from cooker pulled with it's current perl version as well, effectively breaking every perl module package built for 5.18.2.

With this of no relevance or impact affecting anyone else than helping those of us who runs rosa and occationally finds themself necessary to install newer/unavailable packages from cooker, please merge this.
